### PR TITLE
Update _site-publish recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ _site/ : _includes/pubs.html _includes/related.html $(SRC)
 	touch $@
 
 # Build target for publishing to energy/incepts
-_site-publish/ : _includes/pubs.html _includes/related.html $(SRC)
+_site-publish/ : _publish.yml _includes/pubs.html _includes/related.html $(SRC)
 	jekyll build -d $@ --config _config.yml,_publish.yml
 	touch $@
 

--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,7 @@ front_page_news: 8
 
 # Base pathname for links.
 base: "/collections/incepts"
+baseurl: "/collections/incepts"
 
 # make pages for the _projects folder
 collections:

--- a/_publish.yml
+++ b/_publish.yml
@@ -1,2 +1,3 @@
 # Jekyll Configuration file for final publishing
 base: "/energy/incepts"
+baseurl: "/energy/incepts"


### PR DESCRIPTION
Set baseurl flag in _publish.yml so that _project files get their link's resolved correctly

It does seem like we should be using {{ site.baseurl }} instead of {{ site.base }}

Also update Makefile recipe to include _publish.yml as a pre-req of _site-publish